### PR TITLE
Trying to fix simple links for package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,5 +32,8 @@ Copyright: This package is
                                    Applied Analysis and Stochastics.
 URL: http://www.wias-berlin.de/research/ats/imaging/
 Suggests:
-    covr
-RoxygenNote: 6.0.1.9000
+    covr,
+    fmri,
+    aws
+RoxygenNote: 6.1.0
+Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,8 +32,6 @@ Copyright: This package is
                                    Applied Analysis and Stochastics.
 URL: http://www.wias-berlin.de/research/ats/imaging/
 Suggests:
-    covr,
-    fmri,
-    aws
+    covr
 RoxygenNote: 6.1.0
 Encoding: UTF-8

--- a/man/dti-package.Rd
+++ b/man/dti-package.Rd
@@ -19,41 +19,41 @@ The DESCRIPTION file:
 
 Maintainer: \packageMaintainer{dti}
 }
-\references{S. Mohammadi, K. Tabelow, L. Ruthotto, Th. Feiweier, J. Polzehl, 
-            and N. Weiskopf, \emph{High-resolution diffusion kurtosis imaging 
+\references{S. Mohammadi, K. Tabelow, L. Ruthotto, Th. Feiweier, J. Polzehl,
+            and N. Weiskopf, \emph{High-resolution diffusion kurtosis imaging
             at 3T enabled by advanced post-processing}, 8 (2015), 427.
 
             S. Becker, K. Tabelow, S. Mohammadi, N. Weiskopf, and J. Polzehl,
-            \emph{Adaptive smoothing of multi-shell diffusion weighted magnetic 
+            \emph{Adaptive smoothing of multi-shell diffusion weighted magnetic
             resonance data by msPOAS}, NeuroImage 95 (2014), pp. 90-105.
 
             S. Becker, K. Tabelow, H.U. Voss, A. Anwander, R.M. Heidemann and
-            J. Polzehl, \emph{Position-orientation adaptive smoothing of 
+            J. Polzehl, \emph{Position-orientation adaptive smoothing of
             diffusion weighted magnetic resonance data (POAS)}, Medical Image
             Analysis, 16 (2012), pp. 1142-1155.
 
-            J. Polzehl and K. Tabelow, 
+            J. Polzehl and K. Tabelow,
             \emph{Beyond the diffusion tensor model: The package \pkg{dti}},
             Journal of Statistical Software, 44 no. 12 (2011) pp. 1-26.
 
-            K. Tabelow, H.U. Voss and J. Polzehl, 
-            \emph{Modeling the orientation distribution function by 
+            K. Tabelow, H.U. Voss and J. Polzehl,
+            \emph{Modeling the orientation distribution function by
             mixtures of angular central Gaussian distributions},
             Journal of Neuroscience Methods, 203 (2012), pp. 200-211.
 
-            J. Polzehl and K. Tabelow, 
-            \emph{Structural adaptive smoothing in diffusion tensor imaging: 
+            J. Polzehl and K. Tabelow,
+            \emph{Structural adaptive smoothing in diffusion tensor imaging:
             The R package dti}, Journal of Statistical Software, 31 (2009) pp. 1--24.
-             
-            K. Tabelow, J. Polzehl, V. Spokoiny and H.U. Voss. 
-            \emph{Diffusion Tensor Imaging: Structural adaptive smoothing}, 
+
+            K. Tabelow, J. Polzehl, V. Spokoiny and H.U. Voss.
+            \emph{Diffusion Tensor Imaging: Structural adaptive smoothing},
             NeuroImage 39(4), 1763-1773 (2008).
 }
 \keyword{ package }
 \seealso{
-  \code{\link[fmri:fmri-package]{fmri}}
-  \code{\link[aws:aws-package]{aws}}
-  \code{\link[oro.nifti:oro.nifti-package]{oro.nifti}}
+  \href{https://cran.r-project.org/package=fmri}{fmri}
+  \href{https://cran.r-project.org/package=aws}{aws}
+  \href{https://cran.r-project.org/package=oro.nifti}{oro.nifti}
 }
 \examples{
   \dontrun{demo(dti_art)}


### PR DESCRIPTION
The links in `dti-package.Rd` were causing some problems with warnings, which caused this to fail on neuroconductor (and will for CRAN).  Used hyperlinks instead.  See warnings here: https://travis-ci.com/neuroconductor-devel/dti